### PR TITLE
Compensate for offset of PDF CropBox in Adobe OCR JSON format

### DIFF
--- a/src/scripts/adobe/adobe-ocr-to-lb-text-layer.py
+++ b/src/scripts/adobe/adobe-ocr-to-lb-text-layer.py
@@ -49,14 +49,22 @@ for json_filename in json_files:
         
         page_width = 0
         page_height = 0
+        page_left_origin = 0
+        page_bottom_origin = 0
         
         for page in json_content['pages']:
             if page['page_number'] == element['Page']:
                 page_width = page['width']
                 page_height = page['height']
                 
-        
-        [left, bottom, right, top] = bounds
+                # L,B,R,T bounds of page CropBox
+                page_crop_box = page['boxes'].get('CropBox', [0, 0])
+                page_left_origin = page_crop_box[0]
+                page_bottom_origin = page_crop_box[1]
+
+        [left, right] = [c - page_left_origin for c in bounds[0:3:2]]
+        [bottom, top] = [c - page_bottom_origin for c in bounds[1:4:2]]
+
         height = abs(top - bottom)
         width = abs(right - left)
         
@@ -81,7 +89,8 @@ for json_filename in json_files:
         for i in range(len(element['CharBounds'])):
             tokenList = element['CharBounds']
             tokenValue = element['CharBounds'][i]
-            [left, bottom, right, top] = tokenValue
+            [left, right] = [c - page_left_origin for c in tokenValue[0:3:2]]
+            [bottom, top] = [c - page_bottom_origin for c in tokenValue[1:4:2]]
             
             height = abs(top - bottom)
             width = abs(right - left)


### PR DESCRIPTION
The bottom-left corner of a PDF as shown in the Labelbox labeling UI is not necessarily (0,0) in the PDF coordinate system. If the PDF page has a CropBox that's smaller than its MediaBox, the apparent (visual) origin can be greater than (0,0). Furthermore, it's also possible for the entire MediaBox to be offset from (0,0).

This PR adjusts the Adobe OCR JSON format transformer tool to account for the offset of each page's CropBox.

The code change itself should be pretty self-explanatory, but in case the concepts here are unclear I've attached a ZIP with test data for three different scenarios: [Adobe-Coords-Test-Data.zip](https://github.com/Labelbox/PDF-OCR-Transform-CLI/files/12448455/Adobe-Coords-Test-Data.zip)

![PR-graphics-1](https://github.com/Labelbox/PDF-OCR-Transform-CLI/assets/1782032/395c2497-bd40-47bd-a9c0-502498547397)

In the first case, the MediaBox starts at (0,0) but the CropBox is inset and starts at (25,25). An excerpt of the resulting JSON from Adobe's API follows.
```json
"pages": [
    {
        "boxes": {
            "CropBox": [
                24.983993530273438,
                24.983993530273438,
                275.0159912109375,
                175.01600646972656
            ],
            "MediaBox": [
                0.0,
                0.0,
                300.0,
                200.0
            ]
        },
        "height": 150.03201293945312,
        "is_scanned": false,
        "page_number": 0,
        "rotation": 0,
        "width": 250.03199768066406
    }
]
```

In the second case, the MediaBox is inset to (25,25) and the CropBox is coterminous with the same.
```json
"pages": [
    {
        "boxes": {
            "CropBox": [
                26.0,
                26.0,
                275.0,
                175.0
            ],
            "MediaBox": [
                26.0,
                26.0,
                275.0,
                175.0
            ]
        },
        "height": 149.0,
        "is_scanned": false,
        "page_number": 0,
        "rotation": 0,
        "width": 249.0
    }
]
```

In the third case, the MediaBox is inset to (10,10) and the CropBox is further inset by (+15,+15) to (25,25).
```json
"pages": [
    {
        "boxes": {
            "CropBox": [
                24.975997924804688,
                23.975997924804688,
                276.02398681640625,
                175.0240020751953
            ],
            "MediaBox": [
                10.0,
                9.0,
                291.0,
                190.0
            ]
        },
        "height": 151.04800415039062,
        "is_scanned": false,
        "page_number": 0,
        "rotation": 0,
        "width": 251.04798889160156
    }
]
```

(Please pardon some inexactness in the numbers; I had to do some of the cropping by eye.)

The current behavior of the transformer tool (top) causes the resulting text layer to be offset when it is displayed within the Labelbox labeling UI. With the change in this PR, the text layer is correctly positioned in all three cases (bottom).
![PR-graphics-2](https://github.com/Labelbox/PDF-OCR-Transform-CLI/assets/1782032/37c371cc-1672-4b49-8337-0b77328cb7ad)

Note also that, because the CropBox offsets in my test files are relatively small, the incorrectly offset text layer is at least visible in the labeling UI, but if the offsets are quite large the text layer may be shifted entirely offscreen and not visible at all. This is how I initially noticed the bug - I was feeding text layers into Labelbox but they didn't show at all in the UI.
